### PR TITLE
Fix broken link to Ritchie FAQs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ help. If a reviewer realizes you have based your work on the wrong branch, we'll
 let you know so that you can rebase it.
 
 >**Note**: To contribute code to Ritchie projects, see the
-[Ritchie community guidelines](https://docs.ritchiecli.io/community) as well as the 
+[Ritchie FAQs](https://docs.ritchiecli.io/faq) as well as the 
 [Open source contribution guidelines](https://opensource.guide/how-to-contribute/) and our 
 [Code of Conduct](https://github.com/ZupIT/ritchie-cli/blob/master/CODE_OF_CONDUCT.md).
 


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/ritchie-cli/blob/master/CONTRIBUTING.md

For additional information on our contributing process, read our contributing
guide https://docs.ritchiecli.io/community

Please provide the following information:
-->

**- What I did**
I removed the community guidelines broken link and replaced it with an appropriate link pointing to [FAQs](https://docs.ritchiecli.io/faq).
Closes #576
**- How to verify it**
By clicking on the link.
**- Description for the changelog**
Replaced broken link with [FAQs](https://docs.ritchiecli.io/faq).
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
